### PR TITLE
Move eslint no-process-env disable to eslintrc

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -140,7 +140,7 @@ rules:
   no-mixed-requires:
     - error
   no-process-env:
-    - error
+    - off
   no-process-exit:
     - off
   no-sync:

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,8 +4,6 @@
  * Proprietary and confidential.
  */
 
-/* eslint-disable no-process-env */
-
 const _ = require('lodash')
 
 /**


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Move eslint `no-process-env` disable line from `index.js` to `.eslintrc.yml`