### PR TITLE
Reorganize mail environment variables

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -167,11 +167,17 @@ exports.integration = {
 	}
 }
 
-exports.mail = {
+exports.mailgun = {
 	token: process.env.MAILGUN_TOKEN,
 	domain: process.env.MAILGUN_DOMAIN,
 	baseUrl: process.env.MAILGUN_BASE_URL
 }
+
+exports.mail = {
+	type: process.env.MAIL
+}
+
+exports.mail.options = exports[exports.mail.type]
 
 exports.metrics = {
 	token: process.env.MONITOR_SECRET_TOKEN,


### PR DESCRIPTION
Change-type: major
Signed-off-by: Josh Bowling <josh@balena.io>

***

Reorganize mail environment variables so we can abstract Mailgun away to being an integration option for sending email instead of being the one and only option.

Necessary for https://github.com/product-os/jellyfish/pull/4373