### PR TITLE
Use MAIL_TYPE instead of MAIL to avoid collision

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -174,7 +174,7 @@ exports.mailgun = {
 }
 
 exports.mail = {
-	type: process.env.MAIL
+	type: process.env.MAIL_TYPE
 }
 
 exports.mail.options = exports[exports.mail.type]


### PR DESCRIPTION
Change-type: major
Signed-off-by: Josh Bowling <josh@balena.io>

***

Use `MAIL_TYPE` instead of `MAIL` environment variable to determine external mail service type to use. `MAIL` is a common default variable in Unix-ish systems causing a collision and the variable to not get set properly: [Flowdock Conversation](https://www.flowdock.com/app/rulemotion/p-cyclops/threads/5h_iZvnSTh3tbAOcVUn5RElzk8Q)