### PR TITLE
Remove double-quotes from environment variable values

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A module that sets up the Jellyfish system configuration using environment varia
 
 * [environment](#module_environment)
     * [.setNumber(rawValue, fallback)](#module_environment.setNumber) ⇒ <code>Number</code>
+    * [.cleanString(original)](#module_environment.cleanString) ⇒ <code>String</code>
     * [.isProduction()](#module_environment.isProduction) ⇒ <code>Boolean</code>
 
 <a name="module_environment.setNumber"></a>
@@ -40,6 +41,21 @@ A module that sets up the Jellyfish system configuration using environment varia
 **Example**  
 ```js
 const val = setNumber(process.env.MY_VAR, 10)
+```
+<a name="module_environment.cleanString"></a>
+
+### environment.cleanString(original) ⇒ <code>String</code>
+**Kind**: static method of [<code>environment</code>](#module_environment)  
+**Summary**: Clean up an environment variable string, remove whitespace and quotes  
+**Returns**: <code>String</code> - cleaned up string  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| original | <code>String</code> | original string |
+
+**Example**  
+```js
+const result = exports.cleanString(process.env.MY_STRING_VAR)
 ```
 <a name="module_environment.isProduction"></a>
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,6 +29,23 @@ exports.setNumber = (rawValue, fallback) => {
 }
 
 /**
+ * @summary Clean up an environment variable string, remove whitespace and quotes
+ * @function
+ *
+ * @param {String} original - original string
+ * @returns {String} cleaned up string
+ *
+ * @example
+ * const result = exports.cleanString(process.env.MY_STRING_VAR)
+ */
+exports.cleanString = (original) => {
+	if (!_.isString(original) || original === '') {
+		return original
+	}
+	return original.replace(/(^\s*"*)|("*\s*$)/g, '')
+}
+
+/**
  * @summary Check if the code is running in a production environment
  * @function
  * @public
@@ -94,9 +111,9 @@ exports.fileStorage = {
 }
 
 exports.aws = {
-	accessKeyId: _.trim(process.env.AWS_ACCESS_KEY_ID),
-	secretAccessKey: _.trim(process.env.AWS_SECRET_ACCESS_KEY),
-	s3BucketName: _.trim(process.env.AWS_S3_BUCKET_NAME)
+	accessKeyId: exports.cleanString(process.env.AWS_ACCESS_KEY_ID),
+	secretAccessKey: exports.cleanString(process.env.AWS_SECRET_ACCESS_KEY),
+	s3BucketName: exports.cleanString(process.env.AWS_S3_BUCKET_NAME)
 }
 
 exports.redis = {
@@ -121,46 +138,46 @@ exports.pod = {
 
 exports.integration = {
 	default: {
-		user: process.env.INTEGRATION_DEFAULT_USER
+		user: exports.cleanString(process.env.INTEGRATION_DEFAULT_USER)
 	},
 	'balena-api': {
-		privateKey: process.env.INTEGRATION_BALENA_API_PRIVATE_KEY,
+		privateKey: exports.cleanString(process.env.INTEGRATION_BALENA_API_PRIVATE_KEY),
 		production: {
-			publicKey: process.env.INTEGRATION_BALENA_API_PUBLIC_KEY_PRODUCTION
+			publicKey: exports.cleanString(process.env.INTEGRATION_BALENA_API_PUBLIC_KEY_PRODUCTION)
 		},
 		staging: {
-			publicKey: process.env.INTEGRATION_BALENA_API_PUBLIC_KEY_STAGING
+			publicKey: exports.cleanString(process.env.INTEGRATION_BALENA_API_PUBLIC_KEY_STAGING)
 		},
-		appId: process.env.INTEGRATION_BALENA_API_APP_ID,
-		appSecret: process.env.INTEGRATION_BALENA_API_APP_SECRET,
-		oauthBaseUrl: process.env.INTEGRATION_BALENA_API_OAUTH_BASE_URL
+		appId: exports.cleanString(process.env.INTEGRATION_BALENA_API_APP_ID),
+		appSecret: exports.cleanString(process.env.INTEGRATION_BALENA_API_APP_SECRET),
+		oauthBaseUrl: exports.cleanString(process.env.INTEGRATION_BALENA_API_OAUTH_BASE_URL)
 	},
 	github: {
-		api: (process.env.INTEGRATION_GITHUB_TOKEN || '').trim(),
-		signature: (process.env.INTEGRATION_GITHUB_SIGNATURE_KEY || '').trim(),
-		key: (process.env.INTEGRATION_GITHUB_PRIVATE_KEY || '').replace(/\\n/gm, '\n'),
-		appId: process.env.INTEGRATION_GITHUB_APP_ID
+		api: exports.cleanString(process.env.INTEGRATION_GITHUB_TOKEN || ''),
+		signature: exports.cleanString(process.env.INTEGRATION_GITHUB_SIGNATURE_KEY || ''),
+		key: exports.cleanString(process.env.INTEGRATION_GITHUB_PRIVATE_KEY || '').replace(/\\n/gm, '\n'),
+		appId: exports.cleanString(process.env.INTEGRATION_GITHUB_APP_ID)
 	},
 	front: {
-		api: (process.env.INTEGRATION_FRONT_TOKEN || '').trim(),
-		intercom: (process.env.INTEGRATION_INTERCOM_TOKEN || '').trim()
+		api: exports.cleanString(process.env.INTEGRATION_FRONT_TOKEN || ''),
+		intercom: exports.cleanString(process.env.INTEGRATION_INTERCOM_TOKEN || '')
 	},
 	discourse: {
-		api: (process.env.INTEGRATION_DISCOURSE_TOKEN || '').trim(),
-		username: (process.env.INTEGRATION_DISCOURSE_USERNAME || '').trim(),
-		signature: (process.env.INTEGRATION_DISCOURSE_SIGNATURE_KEY || '').trim()
+		api: exports.cleanString(process.env.INTEGRATION_DISCOURSE_TOKEN || ''),
+		username: exports.cleanString(process.env.INTEGRATION_DISCOURSE_USERNAME || ''),
+		signature: exports.cleanString(process.env.INTEGRATION_DISCOURSE_SIGNATURE_KEY || '')
 	},
 	outreach: {
-		appId: _.trim(process.env.INTEGRATION_OUTREACH_APP_ID),
-		appSecret: _.trim(process.env.INTEGRATION_OUTREACH_APP_SECRET),
-		signature: process.env.INTEGRATION_OUTREACH_SIGNATURE_KEY
+		appId: exports.cleanString(process.env.INTEGRATION_OUTREACH_APP_ID),
+		appSecret: exports.cleanString(process.env.INTEGRATION_OUTREACH_APP_SECRET),
+		signature: exports.cleanString(process.env.INTEGRATION_OUTREACH_SIGNATURE_KEY)
 	},
 	flowdock: {
-		api: process.env.INTEGRATION_FLOWDOCK_TOKEN,
-		signature: process.env.INTEGRATION_FLOWDOCK_SIGNATURE_KEY
+		api: exports.cleanString(process.env.INTEGRATION_FLOWDOCK_TOKEN),
+		signature: exports.cleanString(process.env.INTEGRATION_FLOWDOCK_SIGNATURE_KEY)
 	},
 	typeform: {
-		signature: (process.env.INTEGRATION_TYPEFORM_SIGNATURE_KEY || '')
+		signature: exports.cleanString(process.env.INTEGRATION_TYPEFORM_SIGNATURE_KEY || '')
 	},
 	'google-meet': {
 		credentials: process.env.INTEGRATION_GOOGLE_MEET_CREDENTIALS
@@ -180,7 +197,7 @@ exports.mail = {
 exports.mail.options = exports[exports.mail.type]
 
 exports.metrics = {
-	token: process.env.MONITOR_SECRET_TOKEN,
+	token: exports.cleanString(process.env.MONITOR_SECRET_TOKEN),
 	ports: {
 		app: exports.setNumber(process.env.METRICS_PORT, 9000),
 		socket: exports.setNumber(process.env.SOCKET_METRICS_PORT, 9001)
@@ -190,31 +207,31 @@ exports.metrics = {
 exports.test = {
 	integration: {
 		github: {
-			repo: process.env.TEST_INTEGRATION_GITHUB_REPO
+			repo: exports.cleanString(process.env.TEST_INTEGRATION_GITHUB_REPO)
 		},
 		front: {
 			inboxes: [
-				(process.env.TEST_INTEGRATION_FRONT_INBOX_1 || '').trim(),
-				(process.env.TEST_INTEGRATION_FRONT_INBOX_2 || '').trim()
+				exports.cleanString(process.env.TEST_INTEGRATION_FRONT_INBOX_1 || ''),
+				exports.cleanString(process.env.TEST_INTEGRATION_FRONT_INBOX_2 || '')
 			]
 		},
 		discourse: {
-			category: process.env.TEST_INTEGRATION_DISCOURSE_CATEGORY,
-			username: process.env.TEST_INTEGRATION_DISCOURSE_USERNAME,
-			nonModeratorUsername: process.env.TEST_INTEGRATION_DISCOURSE_NON_MODERATOR_USERNAME
+			category: exports.cleanString(process.env.TEST_INTEGRATION_DISCOURSE_CATEGORY),
+			username: exports.cleanString(process.env.TEST_INTEGRATION_DISCOURSE_USERNAME),
+			nonModeratorUsername: exports.cleanString(process.env.TEST_INTEGRATION_DISCOURSE_NON_MODERATOR_USERNAME)
 		},
-		skip: process.env.TEST_INTEGRATION_SKIP
+		skip: exports.setNumber(process.env.TEST_INTEGRATION_SKIP, 0)
 	},
 	jellyfish: {
-		user: process.env.JF_TEST_USER,
-		password: process.env.JF_TEST_PASSWORD,
-		url: process.env.JF_URL
+		user: exports.cleanString(process.env.JF_TEST_USER),
+		password: exports.cleanString(process.env.JF_TEST_PASSWORD),
+		url: exports.cleanString(process.env.JF_URL)
 	},
 	user: {
-		username: process.env.TEST_USER_USERNAME,
-		password: process.env.TEST_USER_PASSWORD,
-		organization: process.env.TEST_USER_ORGANIZATION,
-		role: process.env.TEST_USER_ROLE
+		username: exports.cleanString(process.env.TEST_USER_USERNAME),
+		password: exports.cleanString(process.env.TEST_USER_PASSWORD),
+		organization: exports.cleanString(process.env.TEST_USER_ORGANIZATION),
+		role: exports.cleanString(process.env.TEST_USER_ROLE)
 	}
 }
 
@@ -223,7 +240,7 @@ exports.actions = {
 }
 
 exports.oauth = {
-	redirectBaseUrl: process.env.OAUTH_REDIRECT_BASE_URL
+	redirectBaseUrl: exports.cleanString(process.env.OAUTH_REDIRECT_BASE_URL)
 }
 
 exports.queue = {

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -16,3 +16,18 @@ ava('.setNumber() should return fallback if raw value is not parsable as a numbe
 	const result = environment.setNumber('string', 10)
 	test.is(result, 10)
 })
+
+ava('.cleanString() should return a number if passed a number', (test) => {
+	const result = environment.cleanString(1234)
+	test.is(result, 1234)
+})
+
+ava('.cleanString() should remove leading and trailing whitespace from a string', (test) => {
+	const result = environment.cleanString(' test   ')
+	test.is(result, 'test')
+})
+
+ava('.cleanString() should remove double-quotes from a string', (test) => {
+	const result = environment.cleanString('"test"')
+	test.is(result, 'test')
+})


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

We're getting double-quoted environment variable values from AWS Parameter Store:
```
...
      "github":{
         "api":"\"962e1b8641040d9f5ac4c1a3433xxxxxxxxx\"",
         "signature":"foobar",
...
```

This PR adds the `exports.cleanString` function meant to trim leading and trailing whitespace as well as remove double-quotes.