### PR TITLE
Add CI as test.ci

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -232,7 +232,8 @@ exports.test = {
 		password: exports.cleanString(process.env.TEST_USER_PASSWORD),
 		organization: exports.cleanString(process.env.TEST_USER_ORGANIZATION),
 		role: exports.cleanString(process.env.TEST_USER_ROLE)
-	}
+	},
+	ci: process.env.CI
 }
 
 exports.actions = {


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Josh Bowling <josh@balena.io>

***

Read in the `CI` environment variable as `test.ci`.