### PR TITLE
Execute git add in lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
   "lint-staged": {
     "*.js": [
       "eslint --cache --fix",
-      "npm run doc"
+      "npm run doc",
+      "git add README.md"
     ]
   }
 }


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Noticed that changes made by `lint-staged` aren't automatically added. Copying what's done [in rendition](https://github.com/balena-io-modules/rendition/blob/master/package.json#L152) seems to work.