### PR TITLE
Add integration env var getter

### DIFF
--- a/lib/index.spec.ts
+++ b/lib/index.spec.ts
@@ -4,6 +4,8 @@
  * Proprietary and confidential.
  */
 
+import isEmpty from 'lodash/isEmpty';
+import isPlainObject from 'lodash/isPlainObject';
 import { getEnvironment } from './index';
 
 describe('isProduction()', () => {
@@ -52,6 +54,31 @@ describe('isCI()', () => {
 	});
 });
 
+describe('getIntegration()', () => {
+	test('should return valid data on valid integration name', () => {
+		const environment = getEnvironment({
+			INTEGRATION_GITHUB_APP_ID: '1234',
+		});
+		const github = environment.getIntegration('github');
+		expect(isPlainObject(github)).toBeTruthy();
+		expect(isEmpty(github)).toBeFalsy();
+		expect(github.appId).toBe('1234');
+	});
+
+	test('should throw an error on invalid integration name', () => {
+		const environment = getEnvironment({});
+		expect.assertions(1);
+		const name = 'foobar';
+		try {
+			environment.getIntegration(name);
+		} catch (error) {
+			expect(error).toEqual(
+				new Error(`Environment variables not found for integration "${name}"`),
+			);
+		}
+	});
+});
+
 describe('returned object', () => {
 	test('has all expected keys', () => {
 		const environment = getEnvironment({});
@@ -80,6 +107,7 @@ describe('returned object', () => {
 			'isProduction',
 			'isDevelopment',
 			'isCI',
+			'getIntegration',
 		]);
 	});
 });

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -6,8 +6,8 @@
 
 import { Env } from '@humanwhocodes/env';
 
-import * as utils from './utils';
 import { EnvironmentBuilder, EnvironmentVariables } from './types';
+import * as utils from './utils';
 import { getVariables } from './variables';
 
 /**

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -88,6 +88,18 @@ export interface EnvironmentVariables {
 	 * ```
 	 */
 	isCI: () => boolean;
+
+	/**
+	 * Get environment variables for an integration
+	 *
+	 * @returns Environment variables for specified integration
+	 *
+	 * @example
+	 * ```typescript
+	 * const frontEnvVars = environment.getIntegration('front');
+	 * ```
+	 */
+	getIntegration: (name: string) => any;
 }
 
 export interface EnvironmentBuilder {

--- a/lib/variables/index.ts
+++ b/lib/variables/index.ts
@@ -28,6 +28,8 @@ import { GetTest } from './test';
 import { GetUI } from './ui';
 
 export function getVariables(env: EnvironmentBuilder): EnvironmentVariables {
+	const integration = GetIntegration(env);
+
 	return {
 		actions: GetActions(env),
 		aws: GetAWS(env),
@@ -35,7 +37,7 @@ export function getVariables(env: EnvironmentBuilder): EnvironmentVariables {
 		fileStorage: GetFileStorage(env),
 		flags: GetFlags(env),
 		http: GetHTTP(env),
-		integration: GetIntegration(env),
+		integration,
 		livechat: GetLivechat(env),
 		logentries: GetLogEntries(env),
 		logger: GetLogger(env),
@@ -58,6 +60,16 @@ export function getVariables(env: EnvironmentBuilder): EnvironmentVariables {
 		},
 		isCI: () => {
 			return env.isCI;
+		},
+		getIntegration: (name: string) => {
+			for (const [key, value] of Object.entries(integration)) {
+				if (name === key) {
+					return value;
+				}
+			}
+			throw new Error(
+				`Environment variables not found for integration "${name}"`,
+			);
 		},
 	};
 }


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Josh Bowling <josh@balena.io>

---

Add getter to allow consumers to retrieve environment variables for a given integration name (string).