### PR TITLE
Add HTTP ports for tick and worker instances

### DIFF
--- a/lib/variables/http/index.spec.ts
+++ b/lib/variables/http/index.spec.ts
@@ -9,6 +9,8 @@ import { getEnvironment } from '../../../lib';
 const variables = {
 	SERVER_HOST: 'http://api',
 	SERVER_PORT: '8000',
+	HTTP_TICK_PORT: '8001',
+	HTTP_WORKER_PORT: '8002',
 };
 
 describe('HTTP', () => {
@@ -17,6 +19,8 @@ describe('HTTP', () => {
 		expect(environment.http).toEqual({
 			host: variables.SERVER_HOST,
 			port: variables.SERVER_PORT,
+			tickPort: parseInt(variables.HTTP_TICK_PORT, 10),
+			workerPort: parseInt(variables.HTTP_WORKER_PORT, 10),
 		});
 	});
 });

--- a/lib/variables/http/index.ts
+++ b/lib/variables/http/index.ts
@@ -8,11 +8,15 @@ import { EnvironmentBuilder } from '../../types';
 export interface HTTP {
 	host: string;
 	port: string;
+	tickPort: number;
+	workerPort: number;
 }
 
 export function GetHTTP(env: EnvironmentBuilder): HTTP {
 	return {
 		port: env.getString('SERVER_PORT'),
 		host: env.getString('SERVER_HOST'),
+		tickPort: env.getNumber('HTTP_TICK_PORT'),
+		workerPort: env.getNumber('HTTP_WORKER_PORT'),
 	};
 }


### PR DESCRIPTION
Change-type: minor
Signed-off-by: josh Bowling <josh@balena.io>

---

Add support for HTTP port environment variables for tick and worker servers' readiness/liveness checks.