### PR TITLE
Remove tick port variables

### DIFF
--- a/lib/variables/http/index.spec.ts
+++ b/lib/variables/http/index.spec.ts
@@ -9,7 +9,6 @@ import { getEnvironment } from '../../../lib';
 const variables = {
 	SERVER_HOST: 'http://api',
 	SERVER_PORT: '8000',
-	HTTP_TICK_PORT: '8001',
 	HTTP_WORKER_PORT: '8002',
 	HTTP_TIMEOUT: '61',
 	HTTP_HEADERS_TIMEOUT: '62',
@@ -22,7 +21,6 @@ describe('HTTP', () => {
 		expect(environment.http).toEqual({
 			host: variables.SERVER_HOST,
 			port: variables.SERVER_PORT,
-			tickPort: parseInt(variables.HTTP_TICK_PORT, 10),
 			workerPort: parseInt(variables.HTTP_WORKER_PORT, 10),
 			timeout: parseInt(variables.HTTP_TIMEOUT, 10),
 			headersTimeout: parseInt(variables.HTTP_HEADERS_TIMEOUT, 10),

--- a/lib/variables/http/index.ts
+++ b/lib/variables/http/index.ts
@@ -8,7 +8,6 @@ import { EnvironmentBuilder } from '../../types';
 export interface HTTP {
 	host: string;
 	port: string;
-	tickPort: number;
 	workerPort: number;
 	timeout: number;
 	headersTimeout: number;
@@ -19,7 +18,6 @@ export function GetHTTP(env: EnvironmentBuilder): HTTP {
 	return {
 		port: env.getString('SERVER_PORT'),
 		host: env.getString('SERVER_HOST'),
-		tickPort: env.getNumber('HTTP_TICK_PORT'),
 		workerPort: env.getNumber('HTTP_WORKER_PORT'),
 		timeout: env.getNumber('HTTP_TIMEOUT', 60),
 		headersTimeout: env.getNumber('HTTP_HEADERS_TIMEOUT', 60),


### PR DESCRIPTION
Change-type: major
Signed-off-by: Josh Bowling <josh@balena.io>

---

We have removed the tick server from our backend, so removing related code from the environment as well: https://github.com/product-os/jellyfish/pull/7096