### PR TITLE
Remove defunct test.jellyfish group

### DIFF
--- a/lib/variables/test/index.spec.ts
+++ b/lib/variables/test/index.spec.ts
@@ -9,9 +9,6 @@ const variables = {
 	TEST_INTEGRATION_DISCOURSE_USERNAME: 'foo-2',
 	TEST_INTEGRATION_DISCOURSE_NON_MODERATOR_USERNAME: 'foo-3',
 	TEST_INTEGRATION_SKIP: '1',
-	JF_TEST_USER: 'user-1',
-	JF_TEST_PASSWORD: 'pass-1',
-	JF_URL: 'url-1',
 	TEST_USER_USERNAME: 'user-2',
 	TEST_USER_PASSWORD: 'pass-2',
 	TEST_USER_ORGANIZATION: 'org-1',
@@ -40,11 +37,6 @@ describe('Test', () => {
 						variables.TEST_INTEGRATION_DISCOURSE_NON_MODERATOR_USERNAME,
 				},
 				skip: parseInt(variables.TEST_INTEGRATION_SKIP, 10),
-			},
-			jellyfish: {
-				user: variables.JF_TEST_USER,
-				password: variables.JF_TEST_PASSWORD,
-				url: variables.JF_URL,
 			},
 			user: {
 				username: variables.TEST_USER_USERNAME,

--- a/lib/variables/test/index.ts
+++ b/lib/variables/test/index.ts
@@ -16,11 +16,6 @@ export interface Test {
 		};
 		skip: number;
 	};
-	jellyfish: {
-		user: string;
-		password: string;
-		url: string;
-	};
 	user: {
 		username: string;
 		password: string;
@@ -30,7 +25,6 @@ export interface Test {
 	ci: string;
 }
 
-// TODO: Drop test.jellyfish group as it's not used anywhere.
 export function GetTest(env: EnvironmentBuilder): Test {
 	return {
 		integration: {
@@ -70,11 +64,6 @@ export function GetTest(env: EnvironmentBuilder): Test {
 				'TEST_INTEGRATION_SKIP',
 				defaults.TEST_INTEGRATION_SKIP,
 			),
-		},
-		jellyfish: {
-			user: env.getString('JF_TEST_USER'),
-			password: env.getString('JF_TEST_PASSWORD'),
-			url: env.getString('JF_URL'),
 		},
 		user: {
 			username: env.getString(


### PR DESCRIPTION
Change-type: major
Signed-off-by: Josh Bowling <josh@balena.io>

---

The `environment.test.jellyfish` group is no longer used anywhere so dropping support.

Passed tests in main repo (https://github.com/product-os/jellyfish/pull/7584): https://ci.product-os.io/builds/189450